### PR TITLE
fix(headers): move defconst after Code section

### DIFF
--- a/shell-maker.el
+++ b/shell-maker.el
@@ -6,7 +6,6 @@
 ;; URL: https://github.com/xenodium/shell-maker
 ;; Version: 0.82.3
 ;; Package-Requires: ((emacs "27.1"))
-(defconst shell-maker-version "0.82.3")
 
 ;; This package is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -32,6 +31,8 @@
 ;; Support the work https://github.com/sponsors/xenodium
 
 ;;; Code:
+
+(defconst shell-maker-version "0.82.3")
 
 (require 'comint)
 (require 'goto-addr)


### PR DESCRIPTION
The `defconst` declaration was positioned in the header section between Package-Requires and Commentary, which violates Emacs packaging conventions. All code should appear after the `;;; Code:` marker.

This fixes compatibility with package parsers that expect only comments in the header section.