### PR TITLE
Fix inline-code styling broken after code fences

### DIFF
--- a/markdown-overlays.el
+++ b/markdown-overlays.el
@@ -87,7 +87,8 @@ Objective-C -> (\"objective-c\" . \"objc\")"
   "Put all Markdown overlays."
   (let* ((source-blocks (markdown-overlays--source-blocks))
          (source-block-ranges (seq-map (lambda (block)
-                                  (map-elt block 'body))
+                                  (cons (car (map-elt block 'start))
+                                        (cdr (map-elt block 'end))))
                                 source-blocks))
          (inline-codes (markdown-overlays--markdown-inline-codes source-block-ranges))
          (inline-code-ranges (seq-map (lambda (inline)
@@ -626,10 +627,12 @@ Use START END TEXT-START TEXT-END."
                  (end (match-end 0))
                  (body-start (match-beginning 1))
                  (body-end (match-end 1)))
-            (unless (seq-find (lambda (avoided)
-                                (and (>= begin (car avoided))
-                                     (<= end (cdr avoided))))
-                              avoid-ranges)
+            (if-let ((avoided (seq-find (lambda (avoided)
+                                          (not (or (> begin (cdr avoided))
+                                                   (< end (car avoided)))))
+                                        avoid-ranges)))
+                ;; Match overlaps an avoid range — skip past it and retry
+                (goto-char (1+ (cdr avoided)))
               (push
                (list
                 'body (cons body-start body-end)) codes))


### PR DESCRIPTION
## Problem

The inline-code regex ````[^`\n]+```` can match backticks from the closing ``` fence marker of a code block, creating a spurious inline-code span that extends into the following prose. This inverts all subsequent inline-code styling — text between backtick-quoted spans is rendered as code, and actual ``code`` spans are rendered as normal text.

### How to reproduce

Any markdown buffer with a fenced code block followed by text containing backtick-quoted inline code:

````markdown
```python
print("hello")
```

This uses `random.choice` to pick an item.
````

Without the fix, `random.choice` is not styled as inline code, and the text between the closing fence and the backtick is incorrectly styled.

## Root cause

Two bugs in `markdown-overlays--markdown-inline-codes` and `markdown-overlays-put`:

1. **`source-block-ranges` only covered the body** (content between fences), not the fence markers themselves. The closing ``` was therefore not in any avoid range and its backticks were visible to the inline-code regex.

2. **The avoid-range check required the entire match to be contained inside an avoid range** (`begin >= start AND end <= end`). A match starting at the last backtick of a closing fence and extending into prose would slip through. Additionally, when a match was rejected, `re-search-forward` continued from the end of the rejected match, skipping legitimate inline codes that followed.

## Fix

- Compute `source-block-ranges` from the start of the opening fence to the end of the closing fence (using `start` and `end` instead of `body`)
- Use proper interval overlap detection: two intervals overlap unless one is entirely before the other
- When an avoided match is found, resume scanning from just past the avoid range end so the regex retries and finds legitimate inline codes after the code block