### PR TITLE
Apply face-run overlays code blocks

### DIFF
--- a/markdown-overlays.el
+++ b/markdown-overlays.el
@@ -315,35 +315,34 @@ Use QUOTES1-START QUOTES1-END LANG LANG-START LANG-END BODY-START
                                     (markdown-overlays--resolve-internal-language lang)
                                     (downcase (string-trim lang)))
                                    "-mode")))
-        (string (buffer-substring-no-properties body-start body-end))
-        (pos 0)
-        (props)
-        (overlay)
-        (propertized-text))
+        (string (buffer-substring-no-properties body-start body-end)))
     (if (and markdown-overlays-highlight-blocks
              (fboundp lang-mode))
-        (progn
-          (setq propertized-text
-                (with-current-buffer
-                    (get-buffer-create
-                     (format " *markdown-overlays-fontification:%s*" lang-mode))
-                  (let ((inhibit-modification-hooks nil)
-                        (inhibit-message t))
-                    (erase-buffer)
-                    ;; Additional space ensures property change.
-                    (insert string " ")
-                    (funcall lang-mode)
-                    (font-lock-ensure))
-                  (buffer-string)))
-          (while (< pos (length propertized-text))
-            (setq props (text-properties-at pos propertized-text))
-            (setq overlay (make-overlay (+ body-start pos)
-                                        (+ body-start (1+ pos))))
-            (markdown-overlays--put
-             overlay
-             'evaporate t
-             'face (plist-get props 'face))
-            (setq pos (1+ pos))))
+        (let ((propertized
+               (with-current-buffer
+                   (get-buffer-create
+                    (format " *markdown-overlays-fontification:%s*" lang-mode))
+                 (let ((inhibit-modification-hooks nil)
+                       (inhibit-message t))
+                   (erase-buffer)
+                   ;; Additional space ensures property change.
+                   (insert string " ")
+                   (funcall lang-mode)
+                   (font-lock-ensure))
+                 (buffer-string)))
+              (len (- body-end body-start))
+              (pos 0))
+          (setq len (min len (length propertized)))
+          (while (< pos len)
+            (let ((next (next-single-property-change
+                         pos 'face propertized len))
+                  (face (get-text-property pos 'face propertized)))
+              (when face
+                (markdown-overlays--put
+                 (make-overlay (+ body-start pos) (+ body-start next))
+                 'evaporate t
+                 'face face))
+              (setq pos next))))
       (markdown-overlays--put
        (make-overlay body-start body-end)
        'evaporate t

--- a/tests/markdown-overlays-blocks-tests.el
+++ b/tests/markdown-overlays-blocks-tests.el
@@ -1,0 +1,66 @@
+;;; markdown-overlays-blocks-tests.el --- Tests for code block fontification -*- lexical-binding: t -*-
+
+;;; Code:
+
+(require 'ert)
+(require 'markdown-overlays)
+
+;;; Helpers
+
+(defun markdown-overlays-blocks-tests--code-overlays ()
+  "Return overlays with category `markdown-overlays' and a `face' property.
+Sorted by start position."
+  (sort (seq-filter (lambda (ov)
+                      (and (eq (overlay-get ov 'category) 'markdown-overlays)
+                           (overlay-get ov 'face)
+                           (not (equal (overlay-get ov 'face) '(:box t)))))
+                    (overlays-in (point-min) (point-max)))
+        (lambda (a b)
+          (< (overlay-start a) (overlay-start b)))))
+
+;;; Tests
+
+(ert-deftest markdown-overlays-blocks-test-face-run-overlays ()
+  "Overlays should span contiguous face runs, not individual characters."
+  (with-temp-buffer
+    (insert "```emacs-lisp\n(defun foo (x)\n  x)\n```\n")
+    (markdown-overlays-put)
+    (let ((ovs (markdown-overlays-blocks-tests--code-overlays)))
+      ;; Should have overlays for the code.
+      (should (> (length ovs) 0))
+      ;; The "defun" keyword should be covered by a single overlay.
+      (goto-char (point-min))
+      (search-forward "defun")
+      (let* ((defun-start (match-beginning 0))
+             (defun-end (match-end 0))
+             (defun-ov (seq-find (lambda (ov)
+                                   (and (<= (overlay-start ov) defun-start)
+                                        (>= (overlay-end ov) defun-end)))
+                                 ovs)))
+        (should defun-ov)))))
+
+(ert-deftest markdown-overlays-blocks-test-correct-faces ()
+  "Keyword faces from font-lock should be applied."
+  (with-temp-buffer
+    (insert "```emacs-lisp\n(defun foo (x)\n  x)\n```\n")
+    (markdown-overlays-put)
+    (let ((ovs (markdown-overlays-blocks-tests--code-overlays)))
+      ;; "defun" should get font-lock-keyword-face.
+      (should (seq-find (lambda (ov)
+                          (eq (overlay-get ov 'face)
+                              'font-lock-keyword-face))
+                        ovs)))))
+
+(ert-deftest markdown-overlays-blocks-test-unknown-language-fallback ()
+  "Unknown languages should get a single fallback face overlay."
+  (with-temp-buffer
+    (insert "```unknownlang99\nhello world\n```\n")
+    (markdown-overlays-put)
+    (let ((ovs (markdown-overlays-blocks-tests--code-overlays)))
+      (should (= (length ovs) 1))
+      (should (eq (overlay-get (car ovs) 'face)
+                  'font-lock-doc-markup-face)))))
+
+(provide 'markdown-overlays-blocks-tests)
+
+;;; markdown-overlays-blocks-tests.el ends here


### PR DESCRIPTION
<img width="460" height="742" alt="image" src="https://github.com/user-attachments/assets/4918862b-f740-4483-a72b-d1dd43ccd6ca" />

Original code applied one overlay per character. This uses `next-single-property-change` to add one overlay per continuous run of the same face instead. Hopefully, this should improve performance for syntax highlighting in code blocks.