### PR TITLE
Support files without line numbers and absolute paths on Windows in markdown overlays

### DIFF
--- a/markdown-overlays.el
+++ b/markdown-overlays.el
@@ -834,6 +834,7 @@ Return alist with :file and :line if URL points to an existing file.
 For example:
 
   \"foo.el#L10\"              => ((:file . \"/abs/foo.el\") (:line . 10))
+  \"foo.el\"                  => ((:file . \"/abs/foo.el\") (:line . nil))
   \"file:src/bar.el:5\"       => ((:file . \"/abs/src/bar.el\") (:line . 5))
   \"file:///tmp/baz.el#L20\"  => ((:file . \"/tmp/baz.el\") (:line . 20))
   \"file:///tmp/baz.el\"      => ((:file . \"/tmp/baz.el\") (:line . nil))
@@ -875,7 +876,10 @@ For example:
                      ":" (group (one-or-more digit))
                      eos)
                  url)
-                (cons (match-string 1 url) (match-string 2 url)))))
+                (cons (match-string 1 url) (match-string 2 url)))
+               ;; plain local path with no line suffix
+               ((not (string-empty-p url))
+                (cons url nil))))
              (filepath (expand-file-name (car match))))
     (when (file-exists-p filepath)
       (list (cons :file filepath)

--- a/markdown-overlays.el
+++ b/markdown-overlays.el
@@ -864,7 +864,8 @@ For example:
                ;; path#L123 (GitHub-style line)
                ((string-match
                  (rx bos
-                     (group (one-or-more (not (any ":#"))))
+                     (group (? (optional "/") alpha ":/") ;; Windows drive letter
+                            (one-or-more (not (any ":#"))))
                      "#L" (group (one-or-more digit))
                      eos)
                  url)
@@ -872,7 +873,8 @@ For example:
                ;; path:123 (colon line number)
                ((string-match
                  (rx bos
-                     (group (one-or-more (not (any ":#"))))
+                     (group (? (optional "/") alpha ":/") ;; Windows drive letter
+                            (one-or-more (not (any ":#"))))
                      ":" (group (one-or-more digit))
                      eos)
                  url)

--- a/tests/markdown-overlays-images-tests.el
+++ b/tests/markdown-overlays-images-tests.el
@@ -3,6 +3,7 @@
 ;;; Code:
 
 (require 'ert)
+(require 'cl-lib)
 (require 'markdown-overlays)
 
 ;;; Helpers
@@ -199,6 +200,33 @@
 (ert-deftest markdown-overlays-parse-local-link-test-empty-string ()
   "Do not treat an empty string as a local file link."
   (should-not (markdown-overlays--parse-local-link "")))
+
+(ert-deftest markdown-overlays-parse-local-link-test-windows-path-leading-slash-hash-line ()
+  "Parse /d:/...#L61 as a local file link with line number."
+  (let ((url "/d:/dev/example.java#L61"))
+    (cl-letf (((symbol-function 'file-exists-p) (lambda (_) t)))
+      (should (equal (markdown-overlays--parse-local-link url)
+                     (list (cons :file
+                                 (expand-file-name "/d:/dev/example.java"))
+                           (cons :line 61)))))))
+
+(ert-deftest markdown-overlays-parse-local-link-test-windows-path-leading-slash-colon-line ()
+  "Parse /d:/...:61 as a local file link with line number."
+  (let ((url "/d:/dev/example.java:61"))
+    (cl-letf (((symbol-function 'file-exists-p) (lambda (_) t)))
+      (should (equal (markdown-overlays--parse-local-link url)
+                     (list (cons :file
+                                 (expand-file-name "/d:/dev/example.java"))
+                           (cons :line 61)))))))
+
+(ert-deftest markdown-overlays-parse-local-link-test-windows-path-hash-line ()
+  "Parse d:/...#L61 as a local file link with line number."
+  (let ((url "d:/dev/example.java#L61"))
+    (cl-letf (((symbol-function 'file-exists-p) (lambda (_) t)))
+      (should (equal (markdown-overlays--parse-local-link url)
+                     (list (cons :file
+                                 (expand-file-name "d:/dev/example.java"))
+                           (cons :line 61)))))))
 
 (ert-deftest markdown-overlays-resolve-test-tilde ()
   "Resolve a ~/ path."

--- a/tests/markdown-overlays-images-tests.el
+++ b/tests/markdown-overlays-images-tests.el
@@ -189,6 +189,17 @@
                        (concat "file:" png))
                       (expand-file-name png)))))
 
+(ert-deftest markdown-overlays-parse-local-link-test-plain-path ()
+  "Parse a plain existing path as a local file link."
+  (let ((png (markdown-overlays-images-tests--setup)))
+    (should (equal (markdown-overlays--parse-local-link png)
+                   (list (cons :file (expand-file-name png))
+                         (cons :line nil))))))
+
+(ert-deftest markdown-overlays-parse-local-link-test-empty-string ()
+  "Do not treat an empty string as a local file link."
+  (should-not (markdown-overlays--parse-local-link "")))
+
 (ert-deftest markdown-overlays-resolve-test-tilde ()
   "Resolve a ~/ path."
   (let* ((home (expand-file-name "~"))


### PR DESCRIPTION
Even when I tell my agents to generate file paths with `#L` line numbers, after the context fills up and after compaction it sometimes forgets. I think the guard on `file-exists-p` is enough to filter anyway, so the file overlay rx matching should almost anything as fallback.

Secondly, on Windows, absolute paths have a colon after the drive letter, so those were rejected (the line number not stripped and thus not matched by `file-exists-p`)