### PR TITLE
Fix the shell-maker-restore-session-from-transcript error

### DIFF
--- a/shell-maker.el
+++ b/shell-maker.el
@@ -1516,6 +1516,7 @@ For example, with prompt at positions 100-113:
                       (with-temp-buffer
                         (insert-file-contents path)
                         (shell-maker--extract-history
+                         (shell-maker-prompt-regexp config)
                          ;; prompts from plain text.
                          :propertized nil))))
          (execute-command (shell-maker-config-execute-command


### PR DESCRIPTION
I just find the same problem as #25 . So this PR is trying to fix it. 