### PR TITLE
Fix table emoji alignment via destination-buffer measurement

### DIFF
--- a/markdown-overlays-tables.el
+++ b/markdown-overlays-tables.el
@@ -451,25 +451,51 @@ and any other characters that render taller than the default."
 
 ;;; Column Width Computation
 
-(defvar markdown-overlays--table-char-pixel-width nil
-  "Cached pixel width of a single space character.")
+(defvar-local markdown-overlays--table-char-pixel-width-cache nil
+  "Cons cell (FONT-WIDTH . SPACE-WIDTH) caching real pixel width of a space.")
+
+(defun markdown-overlays--table-measure-string (str window)
+  "Return real pixel width of STR if rendered at point-max of WINDOW's buffer.
+Briefly inserts STR, measures with `window-text-pixel-size', and
+deletes.  Modification hooks and the modified flag are suppressed."
+  (with-current-buffer (window-buffer window)
+    (let ((inhibit-read-only t)
+          (inhibit-modification-hooks t)
+          (modified (buffer-modified-p))
+          real)
+      (save-excursion
+        (goto-char (point-max))
+        (let ((m (point-marker)))
+          (set-marker-insertion-type m nil)
+          (insert str)
+          (setq real (car (window-text-pixel-size window m (point))))
+          (delete-region m (point))
+          (set-marker m nil)))
+      (set-buffer-modified-p modified)
+      real)))
+
+(defun markdown-overlays--table-char-pixel-width (window)
+  "Return real pixel width of a single space in WINDOW, cached.
+Invalidates the cache if the default font width changes (e.g. text scaling)."
+  (let ((fw (window-font-width window)))
+    (if (and markdown-overlays--table-char-pixel-width-cache
+             (= fw (car markdown-overlays--table-char-pixel-width-cache)))
+        (cdr markdown-overlays--table-char-pixel-width-cache)
+      (let ((sw (markdown-overlays--table-measure-string " " window)))
+        (setq markdown-overlays--table-char-pixel-width-cache (cons fw sw))
+        sw))))
 
 (defun markdown-overlays--table-display-width (str)
   "Return display width of STR in character units.
-Uses pixel measurements to detect characters that render wider than
-`string-width' reports (e.g., emoji).  `string-pixel-width' respects
-display properties like (height N) set by height scaling.
-Falls back to `string-width' if `string-pixel-width' is unavailable."
-  ;; ASCII characters render at exactly 1 × space-pixel-width, so
-  ;; `string-width' matches pixel measurement.  Non-ASCII (emoji, CJK)
-  ;; can render wider, requiring expensive `string-pixel-width'.
-  (if (and (fboundp 'string-pixel-width)
+Uses `window-text-pixel-size' for non-ASCII strings to ensure accurate
+measurements of emoji, CJK, and flags in the destination buffer."
+  (if (and (fboundp 'window-text-pixel-size)
            (not (string-match-p (rx bos (* ascii) eos) str)))
-      (let ((char-px (or markdown-overlays--table-char-pixel-width
-                         (setq markdown-overlays--table-char-pixel-width
-                               (string-pixel-width " "))))
-            (actual-px (string-pixel-width str)))
-        (ceiling (/ (float actual-px) char-px)))
+      (let* ((win (or (get-buffer-window (current-buffer))
+                      (selected-window)))
+             (char-px (markdown-overlays--table-char-pixel-width win))
+             (real-px (markdown-overlays--table-measure-string str win)))
+        (ceiling (/ (float real-px) char-px)))
     (string-width str)))
 
 (defun markdown-overlays--preprocess-table (table)
@@ -512,8 +538,6 @@ where each processed-cell is the propertized string from `process-cell-content'.
   "Return display width of longest word in STR."
   (if (or (null str) (string-empty-p str))
       0
-    ;; ASCII renders at exactly 1 × space-pixel-width per char,
-    ;; so cheap `string-width' matches pixel measurement per word.
     (let ((words (split-string str "[ \t\n]+" t)))
       (if words
           (apply #'max (mapcar (if (string-match-p (rx bos (* ascii) eos) str)
@@ -588,30 +612,26 @@ Preserves text properties across wrapped lines."
         (nreverse lines)))))
 
 (defun markdown-overlays--pad-string (str width)
-  "Pad STR with spaces to reach WIDTH.
-Uses pixel measurements when available to compensate for characters
-that render wider than `string-width' reports (e.g., emoji)."
-  ;; ASCII characters render at exactly 1 × space-pixel-width, so
-  ;; column-based padding is pixel-perfect.  Non-ASCII (emoji, CJK)
-  ;; can render wider, requiring pixel-based padding with fractional spaces.
-  (if (and (fboundp 'string-pixel-width)
+  "Pad STR with spaces to reach WIDTH columns.
+Non-ASCII content uses space characters for full columns and a fractional
+pixel-width space for exact sub-pixel alignment."
+  (if (and (fboundp 'window-text-pixel-size)
            (not (string-match-p (rx bos (* ascii) eos) str)))
-      (let* ((char-px (or markdown-overlays--table-char-pixel-width
-                          (setq markdown-overlays--table-char-pixel-width
-                                (string-pixel-width " "))))
+      (let* ((win (or (get-buffer-window (current-buffer))
+                      (selected-window)))
+             (char-px (markdown-overlays--table-char-pixel-width win))
              (target-px (* width char-px))
-             (actual-px (string-pixel-width str))
-             (pad-px (- target-px actual-px)))
+             (content-px (markdown-overlays--table-measure-string str win))
+             (pad-px (- target-px content-px)))
         (if (<= pad-px 0)
             str
           (let* ((full-spaces (floor (/ (float pad-px) char-px)))
-                 (remaining (/ (- (float pad-px) (* full-spaces char-px)) char-px)))
+                 (remaining-px (- pad-px (* full-spaces char-px))))
             (concat str
                     (make-string full-spaces ?\s)
-                    (if (> remaining 0.01)
-                        (propertize " " 'display `(space :width ,remaining))
+                    (if (> remaining-px 0)
+                        (propertize " " 'display `(space :width (,remaining-px)))
                       "")))))
-    ;; ASCII-only or older Emacs — string-width is accurate.
     (let ((current-width (string-width str)))
       (if (>= current-width width)
           str


### PR DESCRIPTION
string-pixel-width can disagree with the actual rendered glyph width by 1-3 pixels for non-ASCII characters (emoji, CJK). The discrepancy depends on the destination buffer's font + fontset configuration.

This PR sidesteps the discrepancy by measuring non-ASCII strings via `window-text-pixel-size` inside the destination buffer itself, which fixes the drift. It also invalidates the pixel-width cache appropriately when text-scaling occurs (e.g. `cmd-+`).

### Screenshots

**Before** (padding drifts with scaled fonts):
<img width="635" height="216" alt="image" src="https://github.com/user-attachments/assets/f1117a2d-b945-4257-a788-a47e86cc2bf9" />

**After** (perfect alignment):
<img width="635" height="216" alt="image" src="https://github.com/user-attachments/assets/1a6d6f67-acdf-472b-a26f-a3d4857e8b32" />