### PR TITLE
Fix source-block copy button copying a stale, truncated range

### DIFF
--- a/markdown-overlays.el
+++ b/markdown-overlays.el
@@ -285,19 +285,25 @@ For example \"elisp\" -> \"emacs-lisp\"."
   "Fontify a source block.
 Use QUOTES1-START QUOTES1-END LANG LANG-START LANG-END BODY-START
  BODY-END QUOTES2-START and QUOTES2-END."
-  ;; Overlay beginning "```" with a copy block button.
-  (markdown-overlays--put
-   (make-overlay quotes1-start quotes1-end)
-   'evaporate t
-   'markdown-overlays-markup-type 'fence
-   'display
-   (propertize "📋 "
-               'pointer 'hand
-               'keymap (markdown-overlays--make-ret-binding-map
-                        (lambda ()
-                          (interactive)
-                          (kill-ring-save body-start body-end)
-                          (message "Copied")))))
+  ;; Overlay beginning "```" with a copy block button.  Capture the body
+  ;; bounds as markers, not the raw integers: the button's closure outlives
+  ;; this call, and if the buffer is edited afterwards (a client streaming or
+  ;; re-rendering around the block) plain integers go stale and the button
+  ;; copies a shifted, truncated range.  Markers track the edits.
+  (let ((body-start (copy-marker body-start))
+        (body-end (copy-marker body-end t)))
+    (markdown-overlays--put
+     (make-overlay quotes1-start quotes1-end)
+     'evaporate t
+     'markdown-overlays-markup-type 'fence
+     'display
+     (propertize "📋 "
+                 'pointer 'hand
+                 'keymap (markdown-overlays--make-ret-binding-map
+                          (lambda ()
+                            (interactive)
+                            (kill-ring-save body-start body-end)
+                            (message "Copied"))))))
   ;; Hide end "```" altogether.
   (markdown-overlays--put
    (make-overlay quotes2-start quotes2-end)


### PR DESCRIPTION
## Summary

The "copy block" button (`📋`) rendered by `markdown-overlays--fontify-source-block`
can copy a **shifted and truncated** range instead of the code block's body. In a
buffer that is edited after rendering — e.g. a client that streams or re-renders
content around the block — clicking the button yields output like:

```
``text
path/to/file.py:120-126
   120	def foo():
   121	    x = 1
   122	    r
```

(note the leading text starts mid-fence with two backticks, and the body is cut
off mid-line) instead of the intended block body.

## Origin of the problem

The button's keymap closes over the **raw integer** positions `body-start` /
`body-end`:

```elisp
'keymap (markdown-overlays--make-ret-binding-map
         (lambda ()
           (interactive)
           (kill-ring-save body-start body-end)   ; plain integers
           (message "Copied")))
```

The overlays created by the same function are marker-backed and therefore track
subsequent buffer edits, but the closed-over integers do not. Once the buffer is
edited after the block is rendered (insertions before the block shift its real
position), the integers point at the old location and `kill-ring-save` copies a
misaligned range.

This was isolated on a live buffer: the opening-fence **overlay** (created by the
same parse) sat correctly on the ```` ``` ````, while the button's captured
integer pointed one character into that fence — i.e. same parse, marker-backed
overlay correct, integer-backed copy range stale. That pinpoints raw integers not
tracking edits as the cause, not a parsing error.

## Fix

Capture the body bounds as markers, scoped to the button closure:

```elisp
(let ((body-start (copy-marker body-start))
      (body-end (copy-marker body-end t)))
  (markdown-overlays--put
   (make-overlay quotes1-start quotes1-end)
   ...
   'keymap (markdown-overlays--make-ret-binding-map
            (lambda ()
              (interactive)
              (kill-ring-save body-start body-end)
              (message "Copied")))))
```

Markers move with buffer edits, so the button copies the correct current range
regardless of later insertions/deletions. `body-end` uses insertion-type `t` so it
grows with body content appended at its position (e.g. during streaming). The rest
of the function is unchanged; the fontification code below still uses the original
values within the same synchronous call.

## Verification

Render a block, copy via the button, insert text before the block, copy again:

```elisp
(with-temp-buffer
  (insert "```python\ndef foo():\n    return 1\n```\n")
  (markdown-overlays-put)
  ;; invoke the button -> "def foo():\n    return 1"
  ;; insert 5 chars before the block, invoke again -> still "def foo():\n    return 1"
  )
```

Before the fix the second copy is shifted/truncated; after the fix both copies
return the identical, correct body (confirmed: `match=t`).
