### PR TITLE
Make submitted prompts read-only

### DIFF
--- a/shell-maker.el
+++ b/shell-maker.el
@@ -345,6 +345,26 @@ Use ON-OUTPUT function to monitor output text."
   (when on-output
     (funcall on-output reply)))
 
+(defun shell-maker--freeze-submitted-input ()
+  "Make the just-submitted input read-only.
+
+Meant to run right after `comint-send-input', while
+`comint-last-input-start' and `comint-last-input-end' still bracket the
+input that was just committed.
+
+`front-sticky' blocks inserting immediately before the input; keeping
+`read-only' out of `rear-nonsticky' (rear-sticky, the default) blocks
+appending immediately after it.  This mirrors the read-only output
+shell-maker already inserts, so a submitted prompt becomes as immutable
+as the agent's reply.  The live prompt stays editable independently, via
+the prompt marker's own `rear-nonsticky' (see `shell-maker--output-filter')."
+  (when (and comint-last-input-start comint-last-input-end
+             (< (marker-position comint-last-input-start)
+                (marker-position comint-last-input-end)))
+    (let ((inhibit-read-only t))
+      (add-text-properties comint-last-input-start comint-last-input-end
+                           '(read-only t front-sticky (read-only))))))
+
 (cl-defun shell-maker-submit (&key input on-output on-finished)
   "Submit current input.
 
@@ -377,6 +397,7 @@ Of the form:
         (goto-char (point-max))
         (insert input)))
     (comint-send-input) ;; Sets shell-maker--input
+    (shell-maker--freeze-submitted-input)
     (when (shell-maker--clear-input-for-execution :input shell-maker--input
                                                   :on-output on-output)
       (if called-interactively


### PR DESCRIPTION
> **Update.** The first version of this PR defaulted the new option to `t` (freeze on by default). It now defaults to **`nil`** (opt-in). Struck-through passages below reflect the earlier default-`t` framing.
>
> The reason: whether editing a past prompt actually matters depends on the shell. Shells that rebuild the next request's conversation from the buffer text (chatgpt-shell and other API shells, via `shell-maker--extract-history`) let an edit genuinely change what the model sees on the next turn — a real, if subtle, feature. Only shells whose conversation state lives elsewhere (agent-shell talking to an agent over ACP) make an edit truly inert. So rather than change shell-maker's default for everyone, this keeps current behavior and lets those front-ends set `shell-maker-input-read-only` to `t` themselves.

## What this fixes

In a shell-maker buffer, everything the agent sends back is read-only — you can't accidentally type over it. But the prompts *you* submitted are not: once a prompt has been sent, its text just sits in the buffer as ordinary, editable text.

~~That's harmless to the agent (the prompt was already sent; editing the buffer copy changes nothing that gets transmitted), but it's~~ Either way, editing one of your own past prompts by accident is an easy way to make a mess. If you scroll back to re-read an earlier exchange and fat-finger a key, you delete or rewrite one of your own past prompts, and now the transcript no longer reflects what was actually asked. For anyone who keeps these sessions around as notes, that can be something annoying and confusing; in any other coding harness I know of, the user cannot edit their own past prompts.

There's a subtler reason, too. In a tool that owns the whole message history — TypingMind, say, or anything talking straight to an LLM API — editing one of your past prompts (or even the agent's past reply) genuinely changes what the model sees on the next turn. That's a real, useful feature.  agent-shell doesn't work that way: it talks to the agent over ACP (the Agent Client Protocol), where a prompt, once submitted, is already part of the agent's context, and editing the buffer copy sends nothing. So an editable past prompt here quietly promises something the protocol can't deliver — it looks like it might branch or rewrite the conversation the way TypingMind does, but it does nothing of the kind. Making it read-only keeps the interface honest about what's actually still changeable.

This PR ~~makes~~ adds an option to make a prompt read-only the moment it's submitted, the same way agent output already is. When enabled, the prompt you're currently typing at the bottom of the buffer stays fully editable — only prompts that have already been sent are frozen.

## Why it happens (background)

shell-maker buffers are built on Emacs' `comint`, the same machinery behind `M-x shell`, the Python REPL, and similar. comint's model is that your input is scratch text you can keep editing.

comint does have a read-only setting, `comint-prompt-read-only`, and shell-maker turns it on. There is however a clash of terminology. In comint, "prompt" means the short string a program prints to invite input, like the `Pi>` glyph at the start of a line. The message the user types to the agent, what, in the context of LLMs, people would naturally call *the prompt*, is not that. comint calls it "input" and treats it as a separate thing.

So the setting does exactly what its name says in comint's vocabulary. It makes the printed `Pi>` glyph read-only, and indeed you cannot delete that glyph. But it never affects the user input. comint has no equivalent setting for input, and that is on purpose: it leaves submitted input editable so you can move point back to an old command, tweak it, and press RET to run it again. This is something very useful for a REPL, but, as explained above, it becomes an annoying and misleading behavior in the context of LLMs.

In fact, for a shell that's a chat with an agent, the correct behavior for a past prompt is to be an immutable record, not to behave like a scratch buffer.  So this is less a comint bug than a mismatch between what comint calls a prompt and what is commonly meant by prompt in the context of LLMs.

## Why the fix lives in shell-maker

This isn't specific to any one agent front-end — it's about how submitted input behaves in the shell buffer, which shell-maker owns. shell-maker already inserts the agent's *output* as read-only; this just extends the same treatment to the input. Doing it here means every shell-maker-based tool benefits, and nothing downstream has to reach into comint internals itself.

## What the change does

Three small pieces, all in `shell-maker.el` (+34 lines, no deletions):

1. **A new option, `shell-maker-input-read-only`** (defaults to ~~`t`~~ `nil`). ~~Set it to `nil` to keep the old behavior where submitted prompts stay editable.~~ Set it to `t` to freeze submitted prompts; front-ends where editing a past prompt is meaningless (say, an ACP agent like agent-shell) may find it preferable to enable it as their default.

2. **A helper, `shell-maker--freeze-submitted-input`.** Right after a prompt is sent, Emacs still knows exactly which span of the buffer that prompt occupies (`comint-last-input-start` … `comint-last-input-end`).  The helper marks that span read-only.

3. **One call to the helper** in `shell-maker-submit`, immediately after the input is committed.

## The one subtle bit (worth reading before reviewing)

Making a region "read-only" in Emacs is done with a text property, and the tricky part is the *edges* of the region. Emacs decides whether you're allowed to insert at a boundary using "stickiness" — whether a property clings to text inserted just before or just after it.

The first attempt froze the prompt but still let the user *append* to the end of it (the user couldn't overwrite existing characters, but could tack text on at the end). That was because the read-only property was set to not cling to its trailing edge — which is the correct setting for the *live* prompt (so you can type the next prompt right after the marker), but the wrong setting here.

The fix is to mirror exactly what shell-maker already does for agent output, which is fully immutable and can't be appended to:

- make read-only cling to the **front** edge → you can't insert just before the prompt either, and
- leave read-only clinging to the **back** edge (the default) → you can't append just after it.

The current prompt at the bottom stays editable regardless, because *its* editability comes from the prompt marker's own stickiness settings (in `shell-maker--output-filter`), not from the frozen input.

## Testing

- Batch test driving a real submit through `shell-maker-submit`: submitted prompts are read-only; editing, appending to, and prepending to an old prompt are all blocked; typing the current prompt still works; with `shell-maker-input-read-only` set to `nil`, prompts stay editable (old behavior preserved).
- The existing history test suite (`tests/shell-maker-history-tests.el`) passes unchanged — history recall reads the prompt *text*, which read-only doesn't touch.
- Exercised interactively in a live agent-shell session: submitted prompts freeze, markdown/image rendering of prompts and streaming responses are unaffected, and the current prompt behaves normally.

## Notes

- Only `shell-maker-submit` is wired up. Two other spots call `comint-send-input` (`shell-maker-interrupt` and `shell-maker-echo`), but there it only commits an empty line as plumbing — no user prompt passes through them — so there's nothing to freeze. The prompt being interrupted was already frozen when it was submitted.
- ~~If you'd rather not add a user-facing option at all and just always freeze submitted prompts, the `shell-maker-input-read-only` defcustom can be dropped and the helper's guard simplified. I personally don't see any use in being able to edit past prompts; however, if we removed the option and some users found a use for it, this PR would feel like a regression.~~ The option defaults to `nil` (see the update at the top), so this changes nothing for existing shells; front-ends where editing a past prompt is meaningless (agent-shell over ACP) opt in by setting it to `t`.
